### PR TITLE
Add autozoom for wiki/nearby API, in addition to animation

### DIFF
--- a/frontend/src/components/Map.js
+++ b/frontend/src/components/Map.js
@@ -965,13 +965,37 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
                                 type="range"
                                 min="10"
                                 max="10000"
-                                step="1000"
                                 value={explorationRadius}
                                 onChange={(e) => setExplorationRadius(parseInt(e.target.value))}
                                 style={{ width: '100%' }}
                             />
-                            <div style={{ textAlign: 'center', marginTop: 4 }}>
-                                {explorationRadius.toLocaleString()}m
+                            <div style={{ 
+                                display: 'flex', 
+                                alignItems: 'center', 
+                                gap: '8px', 
+                                marginTop: 4,
+                                justifyContent: 'center'
+                            }}>
+                                <input
+                                    type="number"
+                                    min="10"
+                                    max="10000"
+                                    value={explorationRadius}
+                                    onChange={(e) => {
+                                        const value = parseInt(e.target.value);
+                                        if (value >= 10 && value <= 10000) {
+                                            setExplorationRadius(value);
+                                        }
+                                    }}
+                                    style={{
+                                        width: '80px',
+                                        padding: '4px 8px',
+                                        border: '1px solid #ccc',
+                                        borderRadius: '4px',
+                                        textAlign: 'center'
+                                    }}
+                                />
+                                <span>m</span>
                             </div>
                         </div>
 

--- a/frontend/src/components/Map.js
+++ b/frontend/src/components/Map.js
@@ -246,7 +246,7 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
                         },
                         ...markers
                     ]);
-                    console.log(`Found ${markers.length} nearby pages`);
+                    console.log(`Found ${markers.length} nearby pages`); // Only backend results.
                 } else {
                     console.error('Failed to fetch nearby pages');
                 }
@@ -1049,7 +1049,7 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
                                 fontSize: '14px',
                                 color: '#1976d2'
                             }}>
-                                Found {explorationMarkers.length} nearby pages
+                                Found <span style={{ fontWeight: 'bold' }}>{explorationMarkers.length-1}</span> nearby pages
                             </div>
                         )}
 


### PR DESCRIPTION
- Get coords of all nearby points from backend. Use them to form a bound, add some padding to it, use `flyToBounds` to create a nice animation where map slowly zooms in to your nearby point cluster area
- Replace slider with keyboard for explorationRadius
- Fix incorrect "Found ${page_count} nearby pages" on frontend