### PR TITLE
Disable re-autoZooming if search parameters are changed and add zoomDelay slider

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -8,7 +8,7 @@ def generate_circle_centers(center_lat, center_lon, radius_km, small_radius_km=1
         - center_lat: Latitude of the center of the larger circle
         - center_lon: Longitude of the center of the larger circle
         - radius_km: Radius of the larger circle in kilometers
-        - small_radius_km: Radius of the smaller circles in kilometers (default 15km)
+        - small_radius_km: Radius of the smaller circles in kilometers (default 10km, more than that wiki api cannot accomodate)
 
         Output:
         - A list of tuples, each containing the latitude and longitude of a small circle's center. [(lat1, lon1), (lat2, lon2),...]

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,4 +1,6 @@
 import math
+import httpx
+
 def generate_circle_centers(center_lat, center_lon, radius_km, small_radius_km=10):
     """
         Generate a list of centers of small circles (radius=10km) needed to cover a larger circle.
@@ -41,3 +43,27 @@ def generate_circle_centers(center_lat, center_lon, radius_km, small_radius_km=1
                 results.append((lat, lon))
     
     return results
+
+
+
+async def fetch_url(client: httpx.AsyncClient, url: str):
+    """
+        Fetch a URL asynchronously using httpx and return the response status and data.
+        This function is asynchrounously used to fetch multiple URLs in parallel when search radius > 10km.
+        Input:
+        - client: httpx.AsyncClient instance
+        - url: URL to fetch
+        Output:
+        - A dictionary with the URL, status code, and data if available.
+            - Data includes the JSON format of wiki geosearch response.
+        If an error occurs, return a dictionary with the URL and the error message.
+    """
+    try:
+        response = await client.get(url, timeout=10.0)
+        return {
+            "url": url,
+            "status": response.status_code,
+            "data": response.json() if response.status_code == 200 else None,
+        }
+    except Exception as e:
+        return {"url": url, "error": str(e)}

--- a/frontend/src/components/Map.js
+++ b/frontend/src/components/Map.js
@@ -92,7 +92,7 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
     const [shouldZoom, setShouldZoom] = useState(false);
 
     // Using CenterMap component to handle centering (for summary/full apis) and for zooming (for wiki/nearby api)
-    const CenterMap = ({ position, coordinates, shouldZoom }) => {
+    const CenterMap = ({ position, coordinates, shouldZoom, setShouldZoom }) => {
         const map = useMap();
         useEffect(() => {
             if (position && Array.isArray(position) && position.length === 2) {
@@ -109,8 +109,9 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
                     maxZoom: 16,
                     duration: 3
                 });
+                setShouldZoom(false);
             }
-        }, [coordinates, map, shouldZoom]);
+        }, [coordinates, map, shouldZoom, setShouldZoom]);
 
         return null;
     };
@@ -614,6 +615,7 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
                         position={markerPosition}
                         coordinates={explorationMarkers.map((marker) => marker.position)}
                         shouldZoom={shouldZoom}
+                        setShouldZoom={setShouldZoom}
                     />
                     {baseLayer === "satellite" && (
                     <>

--- a/frontend/src/components/Map.js
+++ b/frontend/src/components/Map.js
@@ -102,7 +102,7 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
 
 
         useEffect(() => {
-            if (coordinates && Array.isArray(coordinates) && coordinates.length > 0  && shouldZoom) {
+            if (coordinates && Array.isArray(coordinates) && coordinates.length > 1  && shouldZoom) {
                 const bounds = L.latLngBounds(coordinates);
                 map.flyToBounds(bounds, {
                     padding: [50, 50],

--- a/frontend/src/components/Map.js
+++ b/frontend/src/components/Map.js
@@ -90,9 +90,10 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
     const [explorationMarkers, setExplorationMarkers] = useState([]);
     const [explorationSidebarOpen, setExplorationSidebarOpen] = useState(false);
     const [shouldZoom, setShouldZoom] = useState(false);
+    const [zoomDelaySeconds, setZoomDelaySeconds] = useState(3); // Default zoom delay in seconds
 
     // Using CenterMap component to handle centering (for summary/full apis) and for zooming (for wiki/nearby api)
-    const CenterMap = ({ position, coordinates, shouldZoom, setShouldZoom }) => {
+    const CenterMap = ({ position, coordinates, shouldZoom, setShouldZoom, zoomDelaySeconds }) => {
         const map = useMap();
         useEffect(() => {
             if (position && Array.isArray(position) && position.length === 2) {
@@ -104,14 +105,22 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
         useEffect(() => {
             if (coordinates && Array.isArray(coordinates) && coordinates.length > 1  && shouldZoom) {
                 const bounds = L.latLngBounds(coordinates);
-                map.flyToBounds(bounds, {
-                    padding: [50, 50],
-                    maxZoom: 16,
-                    duration: 3
-                });
+                console.log("Delay:", zoomDelaySeconds);
+                if (zoomDelaySeconds > 0) {
+                    map.flyToBounds(bounds, {
+                        padding: [50, 50],
+                        maxZoom: 16,
+                        duration: zoomDelaySeconds
+                    });
+                } else {
+                    map.fitBounds(bounds, {
+                        padding: [50, 50],
+                        maxZoom: 16
+                    });
+                }
                 setShouldZoom(false);
             }
-        }, [coordinates, map, shouldZoom, setShouldZoom]);
+        }, [coordinates, map, shouldZoom, setShouldZoom, zoomDelaySeconds]);
 
         return null;
     };
@@ -616,6 +625,7 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
                         coordinates={explorationMarkers.map((marker) => marker.position)}
                         shouldZoom={shouldZoom}
                         setShouldZoom={setShouldZoom}
+                        zoomDelaySeconds={zoomDelaySeconds}
                     />
                     {baseLayer === "satellite" && (
                     <>
@@ -1039,6 +1049,25 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
                             />
                             <div style={{ textAlign: 'center', marginTop: 4 }}>
                                 {explorationLimit} results
+                            </div>
+                        </div>
+
+
+                        <div>
+                            <label style={{ fontWeight: 500, marginBottom: 8, display: 'block' }}>
+                                Zoom Delay (seconds):
+                            </label>
+                            <input
+                                type="range"
+                                min="0"
+                                max="5"
+                                step="1"
+                                value={zoomDelaySeconds}
+                                onChange={(e) => setZoomDelaySeconds(parseInt(e.target.value))}
+                                style={{ width: '100%' }}
+                            />
+                            <div style={{ textAlign: 'center', marginTop: 4 }}>
+                                {zoomDelaySeconds} sec. zoom duration
                             </div>
                         </div>
 

--- a/frontend/src/components/Map.js
+++ b/frontend/src/components/Map.js
@@ -247,9 +247,7 @@ const Map = ( { onMapClick, searchQuery, contentType, setSearchQuery, setSubmitt
                 
                 if (res.ok) {
                     const data = await res.json();
-                    const markers = data.pages.filter(
-                                page => typeof page.dist === "number" && page.dist <= explorationRadius * 1000
-                            ).map(page => ({
+                    const markers = data.pages.map(page => ({
                         position: [page.lat, page.lon],
                         title: page.title,
                         distance: page.dist

--- a/main.py
+++ b/main.py
@@ -162,7 +162,6 @@ def get_geodistance(payload: Geodistance):
             content={"error": str(e)},
             status_code=500
         )
-
     return JSONResponse(
         content={
             "distance": distance,


### PR DESCRIPTION
- Disable autoZooming if no nearby pages are found
- Returned randomized results if #available nearby pages > #required pages
- Disable re-autoZooming if search parameters (radius, limit) are chaged
- Add a slider to control duration it takes to zoom in on a nearby location cluster